### PR TITLE
Add event handlers for swipe actions on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
-  <link rel="stylesheet" href="styles.css">
-  <script src="script.js" type="module"></script>
-</head>
-<body>
-  <div id="game-board"></div>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2048</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="swiped-events.min.js"></script>
+    <script src="script.js" type="module"></script>
+  </head>
+  <body>
+    <div id="game-board"></div>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -9,7 +9,59 @@ grid.randomEmptyCell().tile = new Tile(gameBoard)
 setupInput()
 
 function setupInput() {
-  window.addEventListener("keydown", handleInput, { once: true })
+  window.addEventListener("keydown", handleInput, { once: true });
+  window.addEventListener("swiped", handleMobileInput, { once: true });
+}
+
+async function handleMobileInput(e) {
+  switch (e.detail.dir) {
+    case "up":
+      if (!canMoveUp()) {
+        setupInput();
+        return;
+      }
+      await moveUp();
+      break;
+    case "down":
+      e.preventDefault();
+      if (!canMoveDown()) {
+        setupInput();
+        return;
+      }
+      await moveDown();
+      break;
+    case "left":
+      if (!canMoveLeft()) {
+        setupInput();
+        return;
+      }
+      await moveLeft();
+      break;
+    case "right":
+      if (!canMoveRight()) {
+        setupInput();
+        return;
+      }
+      await moveRight();
+      break;
+    default:
+      setupInput();
+      return;
+  }
+
+  grid.cells.forEach((cell) => cell.mergeTiles());
+
+  const newTile = new Tile(gameBoard);
+  grid.randomEmptyCell().tile = newTile;
+
+  if (!canMoveUp() && !canMoveDown() && !canMoveLeft() && !canMoveRight()) {
+    newTile.waitForTransition(true).then(() => {
+      alert("Game Over!\nRefresh the page for a new one!");
+    });
+    return;
+  }
+
+  setupInput();
 }
 
 async function handleInput(e) {
@@ -54,7 +106,7 @@ async function handleInput(e) {
 
   if (!canMoveUp() && !canMoveDown() && !canMoveLeft() && !canMoveRight()) {
     newTile.waitForTransition(true).then(() => {
-      alert("You lose")
+      alert("Game Over!\nRefresh the page for a new one!");
     })
     return
   }

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,11 @@
   font-family: Arial;
 }
 
+html,
+body {
+  overscroll-behavior-y: contain;
+}
+
 body {
   background-color: #333;
   display: flex;

--- a/swiped-events.min.js
+++ b/swiped-events.min.js
@@ -1,0 +1,9 @@
+/*!
+ * swiped-events.js - v1.1.6
+ * Pure JavaScript swipe events
+ * https://github.com/john-doherty/swiped-events
+ * @inspiration https://stackoverflow.com/questions/16348031/disable-scrolling-when-touch-moving-certain-element
+ * @author John Doherty <www.johndoherty.info>
+ * @license MIT
+ */
+!function(t,e){"use strict";"function"!=typeof t.CustomEvent&&(t.CustomEvent=function(t,n){n=n||{bubbles:!1,cancelable:!1,detail:void 0};var a=e.createEvent("CustomEvent");return a.initCustomEvent(t,n.bubbles,n.cancelable,n.detail),a},t.CustomEvent.prototype=t.Event.prototype),e.addEventListener("touchstart",function(t){if("true"===t.target.getAttribute("data-swipe-ignore"))return;s=t.target,r=Date.now(),n=t.touches[0].clientX,a=t.touches[0].clientY,u=0,i=0},!1),e.addEventListener("touchmove",function(t){if(!n||!a)return;var e=t.touches[0].clientX,r=t.touches[0].clientY;u=n-e,i=a-r},!1),e.addEventListener("touchend",function(t){if(s!==t.target)return;var e=parseInt(l(s,"data-swipe-threshold","20"),10),o=parseInt(l(s,"data-swipe-timeout","500"),10),c=Date.now()-r,d="",p=t.changedTouches||t.touches||[];Math.abs(u)>Math.abs(i)?Math.abs(u)>e&&c<o&&(d=u>0?"swiped-left":"swiped-right"):Math.abs(i)>e&&c<o&&(d=i>0?"swiped-up":"swiped-down");if(""!==d){var b={dir:d.replace(/swiped-/,""),touchType:(p[0]||{}).touchType||"direct",xStart:parseInt(n,10),xEnd:parseInt((p[0]||{}).clientX||-1,10),yStart:parseInt(a,10),yEnd:parseInt((p[0]||{}).clientY||-1,10)};s.dispatchEvent(new CustomEvent("swiped",{bubbles:!0,cancelable:!0,detail:b})),s.dispatchEvent(new CustomEvent(d,{bubbles:!0,cancelable:!0,detail:b}))}n=null,a=null,r=null},!1);var n=null,a=null,u=null,i=null,r=null,s=null;function l(t,n,a){for(;t&&t!==e.documentElement;){var u=t.getAttribute(n);if(u)return u;t=t.parentNode}return a}}(window,document);


### PR DESCRIPTION
I implemented swipe handlers using an MIT-licensed event library called [swiped-events](https://github.com/john-doherty/swiped-events).

Also added `overscroll-behavior-y: contain;` to `html` and `body` tags in the CSS file to prevent default "pull-to-refresh" behavior.

Since the HTML is responsive, I figured people would want to play on their mobile browsers, too (I have been playing on my phone and it is quite fun :smile:).

Hope this helps.

Best regards.

Cem.